### PR TITLE
feat: drive announcements from database with full CRUD management UI

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,3 +33,4 @@ def root():
 # Include routers
 app.include_router(routers.activities.router)
 app.include_router(routers.auth.router)
+app.include_router(routers.announcements.router)

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -10,6 +10,7 @@ client = MongoClient('mongodb://localhost:27017/')
 db = client['mergington_high']
 activities_collection = db['activities']
 teachers_collection = db['teachers']
+announcements_collection = db['announcements']
 
 # Methods
 
@@ -49,6 +50,11 @@ def init_database():
         for teacher in initial_teachers:
             teachers_collection.insert_one(
                 {"_id": teacher["username"], **teacher})
+
+    # Initialize announcements if empty
+    if announcements_collection.count_documents({}) == 0:
+        for announcement in initial_announcements:
+            announcements_collection.insert_one(announcement)
 
 
 # Initial database if empty
@@ -205,5 +211,15 @@ initial_teachers = [
         "display_name": "Principal Martinez",
         "password": hash_password("admin789"),
         "role": "admin"
+    }
+]
+
+initial_announcements = [
+    {
+        "message": "🎉 Activity registration is now open! Sign up for extracurricular activities before spots fill up. Registration closes at the end of the month.",
+        "starts_at": None,
+        "expires_at": "2026-03-31",
+        "created_by": "principal",
+        "created_at": "2026-03-01T00:00:00+00:00"
     }
 ]

--- a/src/backend/routers/__init__.py
+++ b/src/backend/routers/__init__.py
@@ -1,2 +1,3 @@
 from . import activities
 from . import auth
+from . import announcements

--- a/src/backend/routers/announcements.py
+++ b/src/backend/routers/announcements.py
@@ -112,13 +112,10 @@ def create_announcement(
     _require_teacher(teacher_username)
     _validate_dates(expires_at, starts_at or None)
 
-    if not message or not message.strip():
-        raise HTTPException(status_code=400, detail="Message cannot be empty.")
-    if len(message) > 500:
-        raise HTTPException(status_code=400, detail="Message cannot exceed 500 characters.")
+    sanitized_message = _validate_message(message)
 
     doc = {
-        "message": message.strip(),
+        "message": sanitized_message,
         "expires_at": expires_at,
         "starts_at": starts_at or None,
         "created_by": teacher_username,
@@ -145,10 +142,7 @@ def update_announcement(
     _require_teacher(teacher_username)
     _validate_dates(expires_at, starts_at or None)
 
-    if not message or not message.strip():
-        raise HTTPException(status_code=400, detail="Message cannot be empty.")
-    if len(message) > 500:
-        raise HTTPException(status_code=400, detail="Message cannot exceed 500 characters.")
+    sanitized_message = _validate_message(message)
 
     try:
         object_id = ObjectId(announcement_id)
@@ -156,7 +150,7 @@ def update_announcement(
         raise HTTPException(status_code=400, detail="Invalid announcement ID.")
 
     update_fields = {
-        "message": message.strip(),
+        "message": sanitized_message,
         "expires_at": expires_at,
         "starts_at": starts_at or None,
     }

--- a/src/backend/routers/announcements.py
+++ b/src/backend/routers/announcements.py
@@ -1,0 +1,194 @@
+"""
+Announcements endpoints for the High School Management System API
+"""
+
+from datetime import datetime
+from fastapi import APIRouter, HTTPException, Query
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+
+from ..database import announcements_collection, teachers_collection
+
+router = APIRouter(
+    prefix="/announcements",
+    tags=["announcements"]
+)
+
+
+def _serialize(ann: dict) -> dict:
+    """Convert a MongoDB document to a JSON-serializable dict."""
+    ann["id"] = str(ann.pop("_id"))
+    return ann
+
+
+def _validate_dates(expires_at: str, starts_at: Optional[str]) -> None:
+    """Validate date strings and their relative order."""
+    try:
+        expires_dt = datetime.strptime(expires_at, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid expiration date format. Use YYYY-MM-DD."
+        )
+
+    if starts_at:
+        try:
+            starts_dt = datetime.strptime(starts_at, "%Y-%m-%d")
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid start date format. Use YYYY-MM-DD."
+            )
+        if starts_dt > expires_dt:
+            raise HTTPException(
+                status_code=400,
+                detail="Start date must be on or before expiration date."
+            )
+
+
+def _require_teacher(teacher_username: Optional[str]) -> None:
+    """Raise 401 if the given teacher username is not authenticated."""
+    if not teacher_username:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required for this action."
+        )
+    teacher = teachers_collection.find_one({"_id": teacher_username})
+    if not teacher:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid teacher credentials."
+        )
+
+
+@router.get("", response_model=List[Dict[str, Any]])
+@router.get("/", response_model=List[Dict[str, Any]])
+def get_active_announcements() -> List[Dict[str, Any]]:
+    """
+    Return all currently active announcements (public).
+
+    An announcement is active when:
+    - expires_at >= today, AND
+    - starts_at is null/missing or starts_at <= today
+    """
+    today = datetime.now().strftime("%Y-%m-%d")
+    query = {
+        "expires_at": {"$gte": today},
+        "$or": [
+            {"starts_at": None},
+            {"starts_at": {"$exists": False}},
+            {"starts_at": ""},
+            {"starts_at": {"$lte": today}},
+        ],
+    }
+    return [_serialize(ann) for ann in announcements_collection.find(query).sort("expires_at", 1)]
+
+
+@router.get("/all", response_model=List[Dict[str, Any]])
+def get_all_announcements(
+    teacher_username: Optional[str] = Query(None)
+) -> List[Dict[str, Any]]:
+    """
+    Return all announcements regardless of status.
+    Requires teacher authentication.
+    """
+    _require_teacher(teacher_username)
+    return [_serialize(ann) for ann in announcements_collection.find().sort("expires_at", -1)]
+
+
+@router.post("", response_model=Dict[str, Any])
+def create_announcement(
+    message: str,
+    expires_at: str,
+    starts_at: Optional[str] = None,
+    teacher_username: Optional[str] = Query(None),
+) -> Dict[str, Any]:
+    """
+    Create a new announcement.
+    Requires teacher authentication.
+    expires_at is required; starts_at is optional.
+    """
+    _require_teacher(teacher_username)
+    _validate_dates(expires_at, starts_at or None)
+
+    if not message or not message.strip():
+        raise HTTPException(status_code=400, detail="Message cannot be empty.")
+    if len(message) > 500:
+        raise HTTPException(status_code=400, detail="Message cannot exceed 500 characters.")
+
+    doc = {
+        "message": message.strip(),
+        "expires_at": expires_at,
+        "starts_at": starts_at or None,
+        "created_by": teacher_username,
+        "created_at": datetime.now().isoformat(),
+    }
+    result = announcements_collection.insert_one(doc)
+    doc["id"] = str(result.inserted_id)
+    doc.pop("_id", None)
+    return doc
+
+
+@router.put("/{announcement_id}", response_model=Dict[str, Any])
+def update_announcement(
+    announcement_id: str,
+    message: str,
+    expires_at: str,
+    starts_at: Optional[str] = None,
+    teacher_username: Optional[str] = Query(None),
+) -> Dict[str, Any]:
+    """
+    Update an existing announcement.
+    Requires teacher authentication.
+    """
+    _require_teacher(teacher_username)
+    _validate_dates(expires_at, starts_at or None)
+
+    if not message or not message.strip():
+        raise HTTPException(status_code=400, detail="Message cannot be empty.")
+    if len(message) > 500:
+        raise HTTPException(status_code=400, detail="Message cannot exceed 500 characters.")
+
+    try:
+        object_id = ObjectId(announcement_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid announcement ID.")
+
+    update_fields = {
+        "message": message.strip(),
+        "expires_at": expires_at,
+        "starts_at": starts_at or None,
+    }
+    result = announcements_collection.update_one(
+        {"_id": object_id},
+        {"$set": update_fields},
+    )
+    if result.matched_count == 0:
+        raise HTTPException(status_code=404, detail="Announcement not found.")
+
+    updated = announcements_collection.find_one({"_id": object_id})
+    return _serialize(updated)
+
+
+@router.delete("/{announcement_id}", response_model=Dict[str, Any])
+def delete_announcement(
+    announcement_id: str,
+    teacher_username: Optional[str] = Query(None),
+) -> Dict[str, Any]:
+    """
+    Delete an announcement.
+    Requires teacher authentication.
+    """
+    _require_teacher(teacher_username)
+
+    try:
+        object_id = ObjectId(announcement_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid announcement ID.")
+
+    result = announcements_collection.delete_one({"_id": object_id})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=404, detail="Announcement not found.")
+
+    return {"message": "Announcement deleted successfully."}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -855,6 +855,288 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  // ── Announcement Banner ────────────────────────────────────────────────────
+
+  const announcementBanner = document.getElementById("announcement-banner");
+  const announcementText = document.getElementById("announcement-text");
+  const announcementNav = document.getElementById("announcement-nav");
+  const annCounter = document.getElementById("ann-counter");
+  const annPrev = document.getElementById("ann-prev");
+  const annNext = document.getElementById("ann-next");
+
+  let activeAnnouncements = [];
+  let currentAnnIndex = 0;
+  let annRotateInterval = null;
+
+  function showAnnouncementAt(index) {
+    if (!activeAnnouncements.length) return;
+    currentAnnIndex = (index + activeAnnouncements.length) % activeAnnouncements.length;
+    const ann = activeAnnouncements[currentAnnIndex];
+    announcementText.textContent = ann.message;
+    if (activeAnnouncements.length > 1) {
+      annCounter.textContent = `${currentAnnIndex + 1} / ${activeAnnouncements.length}`;
+      announcementNav.classList.remove("hidden");
+    } else {
+      announcementNav.classList.add("hidden");
+    }
+  }
+
+  function startBannerRotation() {
+    if (annRotateInterval) clearInterval(annRotateInterval);
+    if (activeAnnouncements.length > 1) {
+      annRotateInterval = setInterval(() => {
+        showAnnouncementAt(currentAnnIndex + 1);
+      }, 6000);
+    }
+  }
+
+  async function fetchAndDisplayAnnouncements() {
+    try {
+      const response = await fetch("/announcements");
+      if (!response.ok) return;
+      activeAnnouncements = await response.json();
+    } catch (error) {
+      console.error("Error fetching announcements:", error);
+      activeAnnouncements = [];
+    }
+
+    if (activeAnnouncements.length === 0) {
+      announcementBanner.classList.add("hidden");
+      if (annRotateInterval) clearInterval(annRotateInterval);
+      return;
+    }
+
+    announcementBanner.classList.remove("hidden");
+    showAnnouncementAt(0);
+    startBannerRotation();
+  }
+
+  annPrev.addEventListener("click", () => {
+    showAnnouncementAt(currentAnnIndex - 1);
+    startBannerRotation();
+  });
+
+  annNext.addEventListener("click", () => {
+    showAnnouncementAt(currentAnnIndex + 1);
+    startBannerRotation();
+  });
+
+  // ── Announcements Management Dialog ────────────────────────────────────────
+
+  const manageAnnouncementsBtn = document.getElementById("manage-announcements-btn");
+  const announcementsModal = document.getElementById("announcements-modal");
+  const closeAnnModal = document.querySelector(".close-announcements-modal");
+  const annForm = document.getElementById("ann-form");
+  const annFormTitle = document.getElementById("ann-form-title");
+  const annEditId = document.getElementById("ann-edit-id");
+  const annMessageInput = document.getElementById("ann-message");
+  const annStartsAtInput = document.getElementById("ann-starts-at");
+  const annExpiresAtInput = document.getElementById("ann-expires-at");
+  const annSubmitBtn = document.getElementById("ann-submit-btn");
+  const annCancelEdit = document.getElementById("ann-cancel-edit");
+  const annListDiv = document.getElementById("ann-list");
+  const annFormMessage = document.getElementById("ann-form-message");
+
+  function openAnnouncementsModal() {
+    announcementsModal.classList.remove("hidden");
+    setTimeout(() => announcementsModal.classList.add("show"), 10);
+    resetAnnForm();
+    loadAllAnnouncements();
+  }
+
+  function closeAnnouncementsModal() {
+    announcementsModal.classList.remove("show");
+    setTimeout(() => announcementsModal.classList.add("hidden"), 300);
+  }
+
+  function resetAnnForm() {
+    annEditId.value = "";
+    annForm.reset();
+    annFormTitle.textContent = "Add New Announcement";
+    annSubmitBtn.textContent = "Add Announcement";
+    annCancelEdit.classList.add("hidden");
+    annFormMessage.classList.add("hidden");
+  }
+
+  function showAnnFormMessage(text, type) {
+    annFormMessage.textContent = text;
+    annFormMessage.className = `message ${type}`;
+    annFormMessage.classList.remove("hidden");
+    setTimeout(() => annFormMessage.classList.add("hidden"), 5000);
+  }
+
+  function getAnnouncementStatus(ann) {
+    const today = new Date().toISOString().split("T")[0];
+    if (ann.expires_at < today) return "expired";
+    if (ann.starts_at && ann.starts_at > today) return "upcoming";
+    return "active";
+  }
+
+  function formatDisplayDate(dateStr) {
+    if (!dateStr) return "—";
+    const [year, month, day] = dateStr.split("-");
+    return `${month}/${day}/${year}`;
+  }
+
+  async function loadAllAnnouncements() {
+    if (!currentUser) return;
+    annListDiv.innerHTML = '<p class="ann-loading">Loading...</p>';
+    try {
+      const response = await fetch(
+        `/announcements/all?teacher_username=${encodeURIComponent(currentUser.username)}`
+      );
+      if (!response.ok) {
+        annListDiv.innerHTML = '<p class="ann-loading">Failed to load announcements.</p>';
+        return;
+      }
+      const announcements = await response.json();
+
+      if (announcements.length === 0) {
+        annListDiv.innerHTML = '<p class="ann-empty">No announcements yet. Add one above!</p>';
+        return;
+      }
+
+      annListDiv.innerHTML = "";
+      announcements.forEach((ann) => renderAnnouncementRow(ann));
+    } catch (error) {
+      console.error("Error loading announcements:", error);
+      annListDiv.innerHTML = '<p class="ann-loading">Failed to load announcements.</p>';
+    }
+  }
+
+  function renderAnnouncementRow(ann) {
+    const status = getAnnouncementStatus(ann);
+    const statusLabels = { active: "Active", upcoming: "Upcoming", expired: "Expired" };
+    const row = document.createElement("div");
+    row.className = `ann-row ann-status-${status}`;
+    row.dataset.id = ann.id;
+    row.innerHTML = `
+      <div class="ann-row-status">
+        <span class="ann-badge ann-badge-${status}">${statusLabels[status]}</span>
+      </div>
+      <div class="ann-row-body">
+        <p class="ann-row-message">${escapeHtml(ann.message)}</p>
+        <p class="ann-row-dates">
+          <span>Start: ${formatDisplayDate(ann.starts_at)}</span>
+          <span>Expires: ${formatDisplayDate(ann.expires_at)}</span>
+        </p>
+      </div>
+      <div class="ann-row-actions">
+        <button class="ann-edit-btn icon-btn" title="Edit" aria-label="Edit">✏️</button>
+        <button class="ann-delete-btn icon-btn" title="Delete" aria-label="Delete">🗑️</button>
+      </div>
+    `;
+
+    row.querySelector(".ann-edit-btn").addEventListener("click", () => startEditAnnouncement(ann));
+    row.querySelector(".ann-delete-btn").addEventListener("click", () => confirmDeleteAnnouncement(ann));
+    annListDiv.appendChild(row);
+  }
+
+  function escapeHtml(str) {
+    const div = document.createElement("div");
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  function startEditAnnouncement(ann) {
+    annEditId.value = ann.id;
+    annMessageInput.value = ann.message;
+    annStartsAtInput.value = ann.starts_at || "";
+    annExpiresAtInput.value = ann.expires_at || "";
+    annFormTitle.textContent = "Edit Announcement";
+    annSubmitBtn.textContent = "Save Changes";
+    annCancelEdit.classList.remove("hidden");
+    annFormMessage.classList.add("hidden");
+    annForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  annCancelEdit.addEventListener("click", resetAnnForm);
+
+  annForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!currentUser) return;
+
+    const id = annEditId.value;
+    const message = annMessageInput.value.trim();
+    const startsAt = annStartsAtInput.value || "";
+    const expiresAt = annExpiresAtInput.value;
+
+    if (!message || !expiresAt) {
+      showAnnFormMessage("Message and expiry date are required.", "error");
+      return;
+    }
+
+    const params = new URLSearchParams({
+      message,
+      expires_at: expiresAt,
+      teacher_username: currentUser.username,
+    });
+    if (startsAt) params.set("starts_at", startsAt);
+
+    try {
+      const isEdit = Boolean(id);
+      const url = isEdit
+        ? `/announcements/${encodeURIComponent(id)}?${params}`
+        : `/announcements?${params}`;
+      const method = isEdit ? "PUT" : "POST";
+
+      const response = await fetch(url, { method });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showAnnFormMessage(result.detail || "An error occurred.", "error");
+        return;
+      }
+
+      showAnnFormMessage(
+        isEdit ? "Announcement updated." : "Announcement added.",
+        "success"
+      );
+      resetAnnForm();
+      loadAllAnnouncements();
+      fetchAndDisplayAnnouncements(); // refresh banner
+    } catch (error) {
+      console.error("Error saving announcement:", error);
+      showAnnFormMessage("Failed to save announcement.", "error");
+    }
+  });
+
+  function confirmDeleteAnnouncement(ann) {
+    showConfirmationDialog(
+      `Delete this announcement?\n\n"${ann.message}"`,
+      async () => {
+        try {
+          const response = await fetch(
+            `/announcements/${encodeURIComponent(ann.id)}?teacher_username=${encodeURIComponent(currentUser.username)}`,
+            { method: "DELETE" }
+          );
+          if (!response.ok) {
+            const result = await response.json();
+            showAnnFormMessage(result.detail || "Failed to delete.", "error");
+            return;
+          }
+          loadAllAnnouncements();
+          fetchAndDisplayAnnouncements();
+        } catch (error) {
+          console.error("Error deleting announcement:", error);
+          showAnnFormMessage("Failed to delete announcement.", "error");
+        }
+      }
+    );
+  }
+
+  if (manageAnnouncementsBtn) {
+    manageAnnouncementsBtn.addEventListener("click", openAnnouncementsModal);
+  }
+
+  closeAnnModal.addEventListener("click", closeAnnouncementsModal);
+
+  window.addEventListener("click", (event) => {
+    if (event.target === announcementsModal) closeAnnouncementsModal();
+  });
+
+  // ── Initialize app ──────────────────────────────────────────────────────────
+
   // Expose filter functions to window for future UI control
   window.activityFilters = {
     setDayFilter,
@@ -865,4 +1147,5 @@ document.addEventListener("DOMContentLoaded", () => {
   checkAuthentication();
   initializeFilters();
   fetchActivities();
+  fetchAndDisplayAnnouncements();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -12,8 +12,17 @@
     />
   </head>
   <body>
-    <div class="announcement-banner">
-      📢 Activity registration is open until the end of the month. Don't lose your spot!
+    <!-- Announcement banner: populated dynamically by app.js -->
+    <div id="announcement-banner" class="announcement-banner hidden" role="region" aria-label="Announcements">
+      <div class="announcement-content">
+        <span class="announcement-icon">📢</span>
+        <span id="announcement-text"></span>
+      </div>
+      <div class="announcement-nav hidden" id="announcement-nav">
+        <button class="ann-nav-btn" id="ann-prev" aria-label="Previous announcement">&#8249;</button>
+        <span id="ann-counter"></span>
+        <button class="ann-nav-btn" id="ann-next" aria-label="Next announcement">&#8250;</button>
+      </div>
     </div>
     <header>
       <h1>Mergington High School</h1>
@@ -26,6 +35,10 @@
           </button>
           <div id="user-info" class="hidden">
             <span id="display-name"></span>
+            <button id="manage-announcements-btn" class="icon-button" title="Manage Announcements">
+              <span>📢</span>
+              <span>Announcements</span>
+            </button>
             <button id="logout-button">Logout</button>
           </div>
         </div>
@@ -134,6 +147,51 @@
           <button type="submit">Login</button>
         </form>
         <div id="login-message" class="hidden message"></div>
+      </div>
+    </div>
+
+    <!-- Announcements Management Modal -->
+    <div id="announcements-modal" class="modal hidden">
+      <div class="modal-content announcements-modal-content">
+        <span class="close-announcements-modal">&times;</span>
+        <h3>📢 Manage Announcements</h3>
+
+        <!-- Add / Edit form -->
+        <div id="ann-form-section">
+          <h4 id="ann-form-title">Add New Announcement</h4>
+          <form id="ann-form">
+            <input type="hidden" id="ann-edit-id" value="" />
+            <div class="form-group">
+              <label for="ann-message">Message <span class="required">*</span></label>
+              <textarea id="ann-message" rows="3" required placeholder="Enter announcement message..."></textarea>
+            </div>
+            <div class="ann-dates-row">
+              <div class="form-group">
+                <label for="ann-starts-at">Start Date <span class="optional">(optional)</span></label>
+                <input type="date" id="ann-starts-at" />
+              </div>
+              <div class="form-group">
+                <label for="ann-expires-at">Expiry Date <span class="required">*</span></label>
+                <input type="date" id="ann-expires-at" required />
+              </div>
+            </div>
+            <div class="ann-form-actions">
+              <button type="button" id="ann-cancel-edit" class="btn-secondary hidden">Cancel Edit</button>
+              <button type="submit" id="ann-submit-btn" class="btn-primary">Add Announcement</button>
+            </div>
+          </form>
+          <div id="ann-form-message" class="hidden message"></div>
+        </div>
+
+        <hr class="ann-divider" />
+
+        <!-- Announcements list -->
+        <div id="ann-list-section">
+          <h4>All Announcements</h4>
+          <div id="ann-list">
+            <p class="ann-loading">Loading...</p>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -433,7 +433,8 @@ button {
 }
 
 .close-modal,
-.close-login-modal {
+.close-login-modal,
+.close-announcements-modal {
   position: absolute;
   right: 12px;
   top: 8px;
@@ -627,7 +628,9 @@ footer {
 #user-info {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 #display-name {
@@ -665,9 +668,314 @@ footer {
   background-color: rgba(255, 255, 255, 0.3);
 }
 .announcement-banner {
-  background-color: #4caf50;
-  color: white;
+  background: linear-gradient(135deg, #1565c0 0%, #0d47a1 100%);
+  color: #fff;
+  padding: 10px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 6px;
+  margin-bottom: 10px;
+  box-shadow: 0 2px 8px rgba(21, 101, 192, 0.3);
+  animation: slideDown 0.4s ease;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.announcement-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.announcement-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+#announcement-text {
+  font-size: 0.9rem;
+  line-height: 1.4;
+  font-weight: 500;
+}
+
+.announcement-nav {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+#ann-counter {
+  font-size: 0.75rem;
+  opacity: 0.85;
+  min-width: 36px;
   text-align: center;
-  padding: 15px;
-  font-weight: bold;
+}
+
+.ann-nav-btn {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  color: #fff;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ann-nav-btn:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+/* ── Announcements Management Modal ───────────────────────────────────────── */
+
+.announcements-modal-content {
+  max-width: 620px !important;
+  width: 95% !important;
+  max-height: 88vh;
+  overflow-y: auto;
+  padding: 24px !important;
+}
+
+.announcements-modal-content h3 {
+  color: var(--primary);
+  font-size: 1.25rem;
+  margin-bottom: 20px;
+}
+
+.announcements-modal-content h4 {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+  font-weight: 600;
+}
+
+#ann-form textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-family: inherit;
+  resize: vertical;
+  transition: border-color 0.2s;
+  line-height: 1.45;
+}
+
+#ann-form textarea:focus {
+  outline: none;
+  border-color: var(--primary-light);
+  box-shadow: 0 0 0 3px rgba(83, 75, 174, 0.1);
+}
+
+.ann-dates-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+#ann-form input[type="date"] {
+  width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-family: inherit;
+  transition: border-color 0.2s;
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+#ann-form input[type="date"]:focus {
+  outline: none;
+  border-color: var(--primary-light);
+  box-shadow: 0 0 0 3px rgba(83, 75, 174, 0.1);
+}
+
+.required {
+  color: var(--error);
+  font-size: 0.8rem;
+}
+
+.optional {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 400;
+}
+
+.ann-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.btn-primary {
+  background: linear-gradient(145deg, var(--primary), var(--primary-dark));
+  color: white;
+  border: none;
+  padding: 8px 18px;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(145deg, var(--primary-light), var(--primary));
+  box-shadow: 0 2px 8px rgba(26, 35, 126, 0.3);
+}
+
+.btn-secondary {
+  background: var(--background);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  padding: 8px 18px;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-secondary:hover {
+  background: var(--border-light);
+}
+
+.ann-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 20px 0;
+}
+
+/* Announcement rows in the list */
+.ann-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  margin-bottom: 10px;
+  background: var(--surface);
+  transition: box-shadow 0.2s;
+}
+
+.ann-row:hover {
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
+
+.ann-row-status {
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+
+.ann-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.ann-badge-active {
+  background-color: var(--success-light);
+  color: var(--success);
+}
+
+.ann-badge-upcoming {
+  background-color: #e3f2fd;
+  color: #1565c0;
+}
+
+.ann-badge-expired {
+  background-color: var(--border-light);
+  color: var(--text-secondary);
+}
+
+.ann-row-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.ann-row-message {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  margin-bottom: 5px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.ann-row-dates {
+  display: flex;
+  gap: 14px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.ann-row-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.icon-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: all 0.2s;
+  line-height: 1;
+  color: var(--text-primary);
+}
+
+.icon-btn:hover {
+  background: var(--background);
+  border-color: var(--primary-light);
+}
+
+.ann-status-expired .ann-row-message {
+  color: var(--text-secondary);
+}
+
+.ann-loading,
+.ann-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  padding: 16px 0;
+}
+
+/* Manage announcements button in header */
+#manage-announcements-btn {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  padding: 4px 12px;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  transition: background-color 0.2s;
+}
+
+#manage-announcements-btn:hover {
+  background-color: rgba(255, 255, 255, 0.28);
 }


### PR DESCRIPTION
- Add announcements_collection and initial sample announcement to database.py
- New router: src/backend/routers/announcements.py with GET (public active), GET /all (auth), POST, PUT, DELETE endpoints
- Server-side validation: message required/max 500 chars, date format, start <= expiry
- Dynamic banner in index.html: loads active announcements from API, auto-rotates every 6s, navigation arrows for multiple messages
- Manage Announcements button in header (visible to signed-in users only)
- Management modal: add/edit form with start+expiry dates, list with Active/Upcoming/Expired badges, inline edit and delete with confirmation
- Polished UI: gradient banner, smooth animations, responsive modal